### PR TITLE
Fix PHP warning on array access to null in search

### DIFF
--- a/classes/class-p4ct-search.php
+++ b/classes/class-p4ct-search.php
@@ -116,9 +116,9 @@ if ( ! class_exists( 'P4CT_Search' ) ) {
 		/**
 		 * Main issues
 		 *
-		 * @var int $main_issues;
+		 * @var array $main_issues;
 		 */
-		public $main_issues;
+		public $main_issues = [];
 
 		/**
 		 * P4CT_Search constructor.


### PR DESCRIPTION
Hello :wave: here's a short PR to fix a warning that frequently ends up in Sentry :wrench: 

Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/30/?project=2

`main_issues` can be null in some circonstances, this triggers a warning when trying to acces it as an array.
Declaring it as an array should fix the issue.